### PR TITLE
WIP: Add binary operator and tuple tests

### DIFF
--- a/tests/test_ast_language.py
+++ b/tests/test_ast_language.py
@@ -70,6 +70,11 @@ def test_numeric_literals():
     assert_equivalent_literal('.11e+12')
     assert_equivalent_literal('.13e-14')
 
+def test_simple_math_operations():
+    assert_equivalent_python_text_and_text_ast('1+2', '(+ 1 2)')
+    assert_equivalent_python_text_and_text_ast('1*2', '(* 1 2)')
+    assert_equivalent_python_text_and_text_ast('1/2', '(/ 1 2)')
+    assert_equivalent_python_text_and_text_ast('1-2', '(- 1 2)')
 
 def test_list():
     assert_equivalent_python_text_and_text_ast('[]', '(list)')

--- a/tests/test_ast_language.py
+++ b/tests/test_ast_language.py
@@ -76,6 +76,10 @@ def test_simple_math_operations():
     assert_equivalent_python_text_and_text_ast('1/2', '(/ 1 2)')
     assert_equivalent_python_text_and_text_ast('1-2', '(- 1 2)')
 
+def test_simple_tuple():
+    assert_equivalent_python_text_and_text_ast('(1,2)', '(list 1 2)')
+    assert_equivalent_python_text_and_text_ast('(1,)', '(list 1)')
+
 def test_list():
     assert_equivalent_python_text_and_text_ast('[]', '(list)')
     assert_equivalent_python_text_and_text_ast('[0, 1, 2]', '(list 0 1 2)')


### PR DESCRIPTION
This is the start of implementing binary operators and tuples. We need them for basic math operations which often occur in the queries, and because lots of tuples show up.

- This is a simple test for just the 4 operators
- The output ast-language is probably not correct. In particular, a "call" is probably needed in there.
- We don't have to say "+" - we could say plus
- I do think we should use tuples and lists interchangeably at the back end. so if everything becomes either a tuple or a list that is OK.

So this is just go give a starting point. I'm trying to get this running in my back end.