### PR TITLE
add subscript support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ All defined s-expressions are listed here, though this specification will be exp
   - Lists: `(list <item>*)`
   - Attributes: `(attr <object> <attribute>)`
     - `attribute` must be a string literal
+  - Subscripts: `(subscript <object> <subscript>)`
   - Function calls: `(call <function> <argument>*)`
   - Unary operators: `(<operator> <operand>)`
     - `<operator>` must be `not` (Boolean)

--- a/qastle/transform.py
+++ b/qastle/transform.py
@@ -72,6 +72,14 @@ class PythonASTToTextASTTransformer(ast.NodeVisitor):
     def visit_Attribute(self, node):
         return self.make_composite_node_string('attr', self.visit(node.value), repr(node.attr))
 
+    def visit_Subscript(self, node):
+        return self.make_composite_node_string('subscript',
+                                               self.visit(node.value),
+                                               self.visit(node.slice))
+
+    def visit_Index(self, node):
+        return self.visit(node.value)
+
     def visit_Call(self, node):
         return self.make_composite_node_string('call',
                                                self.visit(node.func),
@@ -217,6 +225,11 @@ class TextASTToPythonASTTransformer(lark.Transformer):
             if not isinstance(fields[1], ast.Str):
                 raise SyntaxError('Attribute name must be a string; found ' + str(type(fields[1])))
             return ast.Attribute(value=fields[0], attr=fields[1].s, ctx=ast.Load())
+
+        elif node_type == 'subscript':
+            if len(fields) != 2:
+                raise SyntaxError('Subscript node must have two fields; found ' + str(len(fields)))
+            return ast.Subscript(value=fields[0], slice=ast.Index(value=fields[1]), ctx=ast.Load())
 
         elif node_type == 'call':
             if len(fields) < 1:

--- a/tests/test_ast_language.py
+++ b/tests/test_ast_language.py
@@ -83,6 +83,11 @@ def test_attr():
     assert_equivalent_python_text_and_text_ast('a.b', "(attr a 'b')")
 
 
+def test_subscript():
+    assert_equivalent_python_text_and_text_ast('a[0]', "(subscript a 0)")
+    assert_equivalent_python_text_and_text_ast("a['b']", "(subscript a 'b')")
+
+
 def test_call():
     assert_equivalent_python_text_and_text_ast('a()', "(call a)")
     assert_equivalent_python_text_and_text_ast('a(0, 1, 2)', "(call a 0 1 2)")


### PR DESCRIPTION
Addresses #21. Only single-element subscripting (via `ast.Index`) is supported.