### PR TITLE
Add support for conditionals

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ All defined s-expressions are listed here, though this specification will be exp
     - `attribute` must be a string literal
   - Subscripts: `(subscript <object> <subscript>)`
   - Function calls: `(call <function> <argument>*)`
+  - Conditionals: `(if <condition> <then> <else>)`
   - Unary operators: `(<operator> <operand>)`
     - `<operator>` must be `not` (Boolean)
   - Binary operators: `(<operator> <operand> <operand>)`

--- a/qastle/transform.py
+++ b/qastle/transform.py
@@ -94,6 +94,12 @@ class PythonASTToTextASTTransformer(ast.NodeVisitor):
                                                self.visit(node.func),
                                                *[self.visit(arg) for arg in node.args])
 
+    def visit_IfExp(self, node):
+        return self.make_composite_node_string('if',
+                                               self.visit(node.test),
+                                               self.visit(node.body),
+                                               self.visit(node.orelse))
+
     def visit_UnaryOp(self, node):
         if (hasattr(ast, 'Constant') and isinstance(node.operand, ast.Constant)
            or isinstance(node.operand, ast.Num)):
@@ -260,6 +266,12 @@ class TextASTToPythonASTTransformer(lark.Transformer):
                                 kwargs=None)
             else:
                 return ast.Call(func=fields[0], args=fields[1:], keywords=[])
+
+        elif node_type == 'if':
+            if len(fields) != 3:
+                raise SyntaxError('If node must have three fields; found '
+                                  + str(len(fields)))
+            return ast.IfExp(test=fields[0], body=fields[1], orelse=fields[2])
 
         elif node_type in UnaryOp_ops:
             if len(fields) == 1:

--- a/tests/test_ast_language.py
+++ b/tests/test_ast_language.py
@@ -99,6 +99,10 @@ def test_call():
     assert_equivalent_python_text_and_text_ast('a(0, 1, 2)', "(call a 0 1 2)")
 
 
+def test_if():
+    assert_equivalent_python_text_and_text_ast('a if b else c', "(if a b c)")
+
+
 def test_unary_operators():
     assert python_source_to_text_ast('+1') == '1'
     assert_ast_nodes_are_equal(text_ast_to_python_ast('+1'), ast.parse('1'))

--- a/tests/test_ast_language.py
+++ b/tests/test_ast_language.py
@@ -100,7 +100,7 @@ def test_call():
 
 
 def test_if():
-    assert_equivalent_python_text_and_text_ast('a if b else c', "(if a b c)")
+    assert_equivalent_python_text_and_text_ast('a if b else c', "(if b a c)")
 
 
 def test_unary_operators():


### PR DESCRIPTION
Adding `(if)` expressions, which are equivalent to `ast.IfExp` in Python. This addresses #30.