### PR TITLE
Raise syntax error on missing source in LINQ nodes

### DIFF
--- a/qastle/linq_util.py
+++ b/qastle/linq_util.py
@@ -85,6 +85,8 @@ class InsertLINQNodesTransformer(ast.NodeTransformer):
             function_name = node.func.id
             if function_name not in linq_operator_names:
                 return self.generic_visit(node)
+            if len(node.args) == 0:
+                raise SyntaxError('LINQ operators must specify a data source to operate on')
             source = node.args[0]
             args = node.args[1:]
         else:

--- a/tests/test_linq_util.py
+++ b/tests/test_linq_util.py
@@ -35,6 +35,11 @@ def test_visit_call_name_linq_operator():
     assert_ast_nodes_are_equal(final_ast, expected_ast)
 
 
+def test_visit_call_name_linq_operator_no_source():
+    with pytest.raises(SyntaxError):
+        insert_linq_nodes(ast.parse("First()"))
+
+
 def test_visit_call_generic():
     initial_ast = ast.parse('None()')
     final_ast = insert_linq_nodes(initial_ast)


### PR DESCRIPTION
Resolves #36