### PR TITLE
Fix `copy.deepcopy` on LINQ nodes

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,4 @@
 [flake8]
+ignore = C901, E241, W503
 max-line-length = 99
 per-file-ignores = __init__.py:F401,F403 tests/*:F403,F405

--- a/qastle/linq_util.py
+++ b/qastle/linq_util.py
@@ -4,82 +4,51 @@ import ast
 
 
 class Where(ast.AST):
-    def __init__(self, source, predicate):
-        self._fields = ['source', 'predicate']
-        self.source = source
-        self.predicate = predicate
+    _fields = ['source', 'predicate']
 
 
 class Select(ast.AST):
-    def __init__(self, source, selector):
-        self._fields = ['source', 'selector']
-        self.source = source
-        self.selector = selector
+    _fields = ['source', 'selector']
 
 
 class SelectMany(ast.AST):
-    def __init__(self, source, selector):
-        self._fields = ['source', 'selector']
-        self.source = source
-        self.selector = selector
+    _fields = ['source', 'selector']
 
 
 class First(ast.AST):
-    def __init__(self, source):
-        self._fields = ['source']
-        self.source = source
+    _fields = ['source']
 
 
 class Aggregate(ast.AST):
-    def __init__(self, source, seed, func):
-        self._fields = ['source', 'seed', 'func']
-        self.source = source
-        self.seed = seed
-        self.func = func
+    _fields = ['source', 'seed', 'func']
 
 
 class Count(ast.AST):
-    def __init__(self, source):
-        self._fields = ['source']
-        self.source = source
+    _fields = ['source']
 
 
 class Max(ast.AST):
-    def __init__(self, source):
-        self._fields = ['source']
-        self.source = source
+    _fields = ['source']
 
 
 class Min(ast.AST):
-    def __init__(self, source):
-        self._fields = ['source']
-        self.source = source
+    _fields = ['source']
 
 
 class Sum(ast.AST):
-    def __init__(self, source):
-        self._fields = ['source']
-        self.source = source
+    _fields = ['source']
 
 
 class Zip(ast.AST):
-    def __init__(self, source):
-        self._fields = ['source']
-        self.source = source
+    _fields = ['source']
 
 
 class OrderBy(ast.AST):
-    def __init__(self, source, key_selector):
-        self._fields = ['source', 'key_selector']
-        self.source = source
-        self.key_selector = key_selector
+    _fields = ['source', 'key_selector']
 
 
 class Choose(ast.AST):
-    def __init__(self, source, n):
-        self._fields = ['source', 'n']
-        self.source = source
-        self.n = n
+    _fields = ['source', 'n']
 
 
 linq_operator_names = ('Where',

--- a/tests/test_linq_util.py
+++ b/tests/test_linq_util.py
@@ -3,6 +3,7 @@ from .testing_util import *
 from qastle import *
 
 import ast
+import copy
 
 import pytest
 
@@ -90,6 +91,21 @@ def test_select_bad():
         insert_linq_nodes(ast.parse('the_source.Select()'))
     with pytest.raises(SyntaxError):
         insert_linq_nodes(ast.parse('the_source.Select(None)'))
+
+
+def test_select_copy():
+    select = Select('src', 'slctr')
+    select_copy = copy.copy(select)
+    assert select_copy.source == select.source and select_copy.selector == select.selector
+
+
+def test_select_deepcopy():
+    select = Select('src', 'slctr')
+    select_copy = copy.deepcopy(select)
+    assert select_copy.source == select.source and select_copy.selector == select.selector
+    select.source = 'src2'
+    select.selector = 'slctr2'
+    assert select_copy.source == 'src' and select_copy.selector == 'slctr'
 
 
 def test_selectmany():


### PR DESCRIPTION
Don't override constructor for the LINQ `ast.AST` nodes. This ensures that `copy.copy()` and `copy.deepcopy()` work properly.

Resolves #51.